### PR TITLE
Fix compilation error when using -Werror=format-security

### DIFF
--- a/ext/trie/trie.c
+++ b/ext/trie/trie.c
@@ -21,7 +21,7 @@ static VALUE rb_trie_alloc(VALUE klass) {
 
 void raise_ioerror(const char * message) {
     VALUE rb_eIOError = rb_const_get(rb_cObject, rb_intern("IOError"));
-    rb_raise(rb_eIOError, message);
+    rb_raise(rb_eIOError, "%s", message);
 }
 
 /*


### PR DESCRIPTION
Passing a variable as a format string is a potential security issue. Fixes compilation on Ubuntu 14.04 64 bit.
